### PR TITLE
Fixing #479

### DIFF
--- a/packages/ads/ios/Classes/ScreenStatus.swift
+++ b/packages/ads/ios/Classes/ScreenStatus.swift
@@ -18,101 +18,26 @@ enum Status: String {
 
 class Screen {
     func addNotificationObservers() {
-        //let lockCompleteString = "com.apple.springboard.lockcomplete"
-        //let lockString = "com.apple.springboard.lockstate"
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(AdsViewController.applicationDidBecomeActive(notification:)),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil);
 
-        // Listen to CFNotification, post Notification accordingly.
-        // CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(),
-        //                                 nil,
-        //                                 { (_, _, _, _, _) in
-        //                                     NotificationCenter.default.post(name: NotificationName.lockComplete, object: nil)
-        //                                 },
-        //                                 lockCompleteString as CFString,
-        //                                 nil,
-        //                                 CFNotificationSuspensionBehavior.deliverImmediately)
-
-        // CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(),
-        //                                 nil,
-        //                                 { (_, _, _, _, _) in
-        //                                     NotificationCenter.default.post(name: NotificationName.lockState, object: nil)
-        //                                 },
-        //                                 lockString as CFString,
-        //                                 nil,
-        //                                 CFNotificationSuspensionBehavior.deliverImmediately)
-
-        // Listen to Notification and handle.
-        NotificationCenter.default.addObserver(self,
-                                                selector: #selector(onLockComplete),
-                                                name: NotificationName.lockComplete,
-                                                object: nil)
-
-        NotificationCenter.default.addObserver(self,
-                                                selector: #selector(onLockState),
-                                                name: NotificationName.lockState,
-                                                object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(AdsViewController.applicationDidEnterBackground(notification:)),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil);
     }
-    
-    // nil means don't know; ture or false means we did or did not received such notification.
-    var receiveLockStateNotification: Bool? = nil
-    // when we received lockState notification, use timer to wait 0.3s for the lockComplete notification.
-    var waitForLockCompleteNotificationTimer: Timer? = nil
-    var receiveLockCompleteNotification: Bool? = nil
+
+    @objc func applicationDidBecomeActive(notification: NSNotification) {
+        self.status = .unlocked
+    }
+
+    @objc func applicationDidEnterBackground(notification: NSNotification) {
+        self.status = .locked
+    }
+
     var status: Status = .unlocked
-
-    // When we received lockComplete notification, invalidate timer and refresh lock status.
-    @objc
-    func onLockComplete() {
-        if let timer = waitForLockCompleteNotificationTimer {
-            timer.invalidate()
-            waitForLockCompleteNotificationTimer = nil
-        }
-
-        receiveLockCompleteNotification = true
-        changeIsLockedIfNeeded()
-    }
-
-    // When we received lockState notification, refresh lock status.
-    @objc
-    func onLockState() {
-        receiveLockStateNotification = true
-        changeIsLockedIfNeeded()
-    }
-
-    func changeIsLockedIfNeeded() {
-        guard let state = receiveLockStateNotification, state else {
-            // If we don't receive lockState notification, return.
-            return
-        }
-
-        guard let complete = receiveLockCompleteNotification else {
-            // If we don't receive lockComplete notification, wait 0.3s.
-            // If nothing happens in 0.3s, then make sure we don't receive lockComplete, and refresh lock status.
-            
-            if #available(iOS 10.0, *) {
-                waitForLockCompleteNotificationTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: false, block: { _ in
-                    self.receiveLockCompleteNotification = false
-                    self.changeIsLockedIfNeeded()
-                })
-            } else {
-                // Fallback on earlier versions
-            }
-            return
-        }
-        
-        let oldStat = self.status
-        self.status = complete ? Status.locked : Status.unlocked
-        
-        print("Screen status changed from \(oldStat) to \(self.status)" )
-        
-        // When we determined lockState and lockComplete notification is received or not.
-        // We can update the device lock status by 'complete' value.
-        NotificationCenter.default.post(
-            name: complete ? NotificationName.locked : NotificationName.unlocked,
-            object: nil
-        )
-
-        // Reset status.
-        receiveLockStateNotification = nil
-        receiveLockCompleteNotification = nil
-    }
 }

--- a/packages/ads/ios/Classes/SwiftSmadsPlugin.swift
+++ b/packages/ads/ios/Classes/SwiftSmadsPlugin.swift
@@ -46,6 +46,10 @@ public class SwiftSmadsPlugin: NSObject, FlutterPlugin {
         SwiftSmadsPlugin.channel?.invokeMethod("onComplete", arguments: [String: String]())
     }
     
+    fileprivate func onError() {
+        SwiftSmadsPlugin.channel?.invokeMethod("onError", arguments: [String: String]())
+    }
+    
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "load":
@@ -76,7 +80,7 @@ public class SwiftSmadsPlugin: NSObject, FlutterPlugin {
                                 rootViewController?.present(adsViewController, animated: false, completion: nil)
                                 result(1)
                             } else {
-                                self.onComplete()
+                                self.onError()
                                 result(-1)
                             }
 //                        } else {

--- a/packages/ads/ios/Classes/SwiftSmadsPlugin.swift
+++ b/packages/ads/ios/Classes/SwiftSmadsPlugin.swift
@@ -4,6 +4,8 @@ import UIKit
 public class SwiftSmadsPlugin: NSObject, FlutterPlugin {
     static var channel: FlutterMethodChannel?
     private var screen: Screen
+    static let NoConnectivity = -1;
+    static let ScreenIsLocked = -2;
 
     fileprivate static func verifyNetworkAccess() {
         do {
@@ -46,8 +48,9 @@ public class SwiftSmadsPlugin: NSObject, FlutterPlugin {
         SwiftSmadsPlugin.channel?.invokeMethod("onComplete", arguments: [String: String]())
     }
     
-    fileprivate func onError() {
-        SwiftSmadsPlugin.channel?.invokeMethod("onError", arguments: [String: String]())
+    fileprivate func onError(code: Int) {
+        let arguments = ["error": code]
+        SwiftSmadsPlugin.channel?.invokeMethod("onError", arguments: arguments)
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -66,7 +69,7 @@ public class SwiftSmadsPlugin: NSObject, FlutterPlugin {
                             SwiftSmadsPlugin.verifyNetworkAccess()
                         }
                         
-//                        if (self.screen.status == .unlocked) {
+                        if (self.screen.status == .unlocked) {
                             if (Network.reachability.isReachable) {                                
                                 let adsViewController:AdsViewController = AdsViewController.instantiateFromNib()
                                 adsViewController.setup(
@@ -80,13 +83,13 @@ public class SwiftSmadsPlugin: NSObject, FlutterPlugin {
                                 rootViewController?.present(adsViewController, animated: false, completion: nil)
                                 result(1)
                             } else {
-                                self.onError()
-                                result(-1)
+                                self.onError(code: SwiftSmadsPlugin.NoConnectivity)
+                                result(SwiftSmadsPlugin.NoConnectivity)
                             }
-//                        } else {
-//                            self.onComplete()
-//                            result(-2)
-//                        }
+                        } else {
+                            self.onError(code: SwiftSmadsPlugin.ScreenIsLocked)
+                            result(SwiftSmadsPlugin.ScreenIsLocked)
+                        }
                         
                     }
                 } catch {

--- a/packages/ads/lib/smads.dart
+++ b/packages/ads/lib/smads.dart
@@ -13,13 +13,14 @@ class SMAds {
   final adUrl;
   final contentUrl;
   static const Ok = 1;
-  static const NotOk = -1;
+  static const NoConnectivity = -1;
+  static const ScreenIsLocked = -2;
   static final MethodChannel _channel = const MethodChannel('smads')
     ..setMethodCallHandler(platformCallHandler);
 
   static SMAds lastAd;
   Function onComplete;
-  Function onError;
+  Function(int) onError;
 
   final StreamController<AdEvent> _eventStreamController =
       StreamController<AdEvent>();
@@ -36,7 +37,7 @@ class SMAds {
   Future<int> load(
     Map<String, dynamic> args, {
     Function onComplete,
-    Function onError,
+    Function(int) onError,
   }) async {
     this.onComplete = onComplete;
     this.onError = onError;
@@ -87,7 +88,8 @@ class SMAds {
 
       case 'onError':
         if (lastAd != null && lastAd.onError != null) {
-          lastAd.onError();
+          final error = callArgs["error"] as int;
+          lastAd.onError(error);
         }
 
         break;

--- a/packages/ads/lib/smads.dart
+++ b/packages/ads/lib/smads.dart
@@ -19,6 +19,7 @@ class SMAds {
 
   static SMAds lastAd;
   Function onComplete;
+  Function onError;
 
   final StreamController<AdEvent> _eventStreamController =
       StreamController<AdEvent>();
@@ -32,8 +33,13 @@ class SMAds {
     return _stream;
   }
 
-  Future<int> load(Map<String, dynamic> args, Function onComplete) async {
+  Future<int> load(
+    Map<String, dynamic> args, {
+    Function onComplete,
+    Function onError,
+  }) async {
     this.onComplete = onComplete;
+    this.onError = onError;
     SMAds.lastAd = this;
     args["__URL__"] = adUrl;
     args["__CONTENT__"] = contentUrl;
@@ -75,6 +81,13 @@ class SMAds {
       case 'onComplete':
         if (lastAd != null && lastAd.onComplete != null) {
           lastAd.onComplete();
+        }
+
+        break;
+
+      case 'onError':
+        if (lastAd != null && lastAd.onError != null) {
+          lastAd.onError();
         }
 
         break;

--- a/packages/player/ios/Classes/Plugin.m
+++ b/packages/player/ios/Classes/Plugin.m
@@ -192,17 +192,17 @@ id previousTrackId;
 }
 
 -(void)disableNotificationCommands:(NSString *) playerId {
-    NSLog(@"Player: MPRemote: Disabling Remote Command Center...");
+    NSLog(@"Player: MPRemote: Disabling Remote Commands: START");
     NSMutableDictionary * playerInfo = players[playerId];
     [playerInfo setValue:@false forKey:@"areNotificationCommandsEnabled"];
-    NSLog(@"Player: MPRemote: Disabled Remote Command Center! Done!");
+    NSLog(@"Player: MPRemote: Disabled Remote Commands: END");
 }
 
 -(void)enableNotificationCommands:(NSString *) playerId {
-    NSLog(@"Player: MPRemote: Disabling Remote Command Center...");
+    NSLog(@"Player: MPRemote: Enabling Remote Commands: START");
     NSMutableDictionary * playerInfo = players[playerId];
     [playerInfo setValue:@true forKey:@"areNotificationCommandsEnabled"];
-    NSLog(@"Player: MPRemote: Disabled Remote Command Center! Done!");
+    NSLog(@"Player: MPRemote: Enabling Remote Commands: END");
 }
 
 

--- a/packages/player/lib/src/player.dart
+++ b/packages/player/lib/src/player.dart
@@ -129,8 +129,13 @@ class Player {
     return Ok;
   }
 
-  Future<int> disableNotificatonBeforeAd() async {
-    await _invokeMethod('disable_remote_center_before_ad');
+  Future<int> disableNotificatonCommands() async {
+    await _invokeMethod('disable_notification_commands');
+    return Ok;
+  }
+
+  Future<int> enableNotificatonCommands() async {
+    await _invokeMethod('enable_notification_commands');
     return Ok;
   }
 


### PR DESCRIPTION
Como combinado com o @atrope:

- O preroll não vai mais tocar quando o App estiver em segundo plano;
- Se o preroll tiver que tocar, mas o App estiver em segundo plano, o preroll vai ficar marcado para tocar quando o App estiver novamente em primeiro plano e o player for para próxima música;
- No Remote Control Center somente a opção de Play/Pause estará habilitada para Ads (next e previous desabilitados);
