### PR TITLE
Fixing bug

### DIFF
--- a/packages/equalizer/lib/equalizer.dart
+++ b/packages/equalizer/lib/equalizer.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:equalizer/equalizer_controller.dart';
 import 'package:flutter/services.dart';
+
+import 'equalizer_controller.dart';
 
 enum CONTENT_TYPE { MUSIC, MOVIE, GAME, VOICE }
 
@@ -47,7 +50,11 @@ class Equalizer {
   ///
   /// [audioSessionId] enable audio effects for the current session.
   static Future<void> initWithPresets(EQInit initialization) async {
-    _methodChannelPrefix = _METHOD_CHANNEL_EXTERNAL_PRESETS_PREFIX;
+    if (Platform.isAndroid) {
+      _methodChannelPrefix = _METHOD_CHANNEL_EXTERNAL_PRESETS_PREFIX;
+    } else {
+      _methodChannelPrefix = _METHOD_CHANNEL_DEFAULT_PREFIX;
+    }
     await _channel.invokeMethod(
         appendMethodPrefix('init'), initialization.toPlatformInput());
   }

--- a/packages/equalizer/pubspec.yaml
+++ b/packages/equalizer/pubspec.yaml
@@ -1,6 +1,6 @@
 name: equalizer
 description: A new flutter plugin project.
-version: 0.0.2
+version: 0.0.3
 author:
 homepage:
 


### PR DESCRIPTION
## Correção do Bug no Equalizer

 - Fixed: fix(Equalizer): Fixed Equalizer bug.
 - Relacionado com a issue https://github.com/SuaMusica/OneApp/issues/1828 do OneApp

## Qual feature foi feita (Breve descrição do que foi feito)*

Hi @koga187 and @jefersonkrauss,

I just found and fixed the bug on the Equilizer code base. I had some trouble understanding why the equalizer iOS codebase has so much source code as it is not being used. I think we should open an issue to clean up this codebase.

It is also important to notice that the person that changed the `initWithPreset` method forgot to check the impacts on iOS. Every single time that we change anything on the Equilizer we need to remember checking the impacts on Android and iOS.

## Evidências do teste (Obrigatório para novas funcionalidades exceto testes)

- 1 - Se for alteração de widget adicionar um print e um video como evidência
- 2 - Se for unitário print do log dos testes e cobertura do arquivo.

## Observações:

 - [ ] Rodar o teste antes de subir o PR
 - [ ] Manter o PR sempre atualizado com a master
 - [x] Adicionar a label *READ TO TEST* na issue.
 - [x] Vincular a issue ao PR
 - [x] Vincular Milestone