### PR TITLE
Bugfix: 2255 chrome cast pause ios

### DIFF
--- a/packages/player/lib/src/player.dart
+++ b/packages/player/lib/src/player.dart
@@ -92,7 +92,7 @@ class Player {
 
     return _channel
         .invokeMethod(method, args)
-        .then((result) => (result as int));
+        .then((result) => result == null? Future.value(Ok) : result);
   }
 
   Future<int> enqueue(

--- a/packages/player/lib/src/player.dart
+++ b/packages/player/lib/src/player.dart
@@ -92,7 +92,7 @@ class Player {
 
     return _channel
         .invokeMethod(method, args)
-        .then((result) => result == null? Future.value(Ok) : result);
+        .then((result) => result ?? Future.value(Ok));
   }
 
   Future<int> enqueue(


### PR DESCRIPTION
Este PR é um bugFix que permite os usuarios de iOS pausar uma musica através do player, como descreve a issue  [#2255](https://github.com/SuaMusica/OneApp/issues/2255)

Produção: https://drive.google.com/file/d/1uJfyi0mHQnuWr6U6C1GK_Hn59DxJ-J5e/view?usp=sharing
Evidencia com as 2 correçoes: https://drive.google.com/file/d/14HnUhI0AI30HLWwHMmzDE9i12odFXk1P/view?usp=sharing
