### PR TITLE
fix replaceCurrent Method

### DIFF
--- a/packages/player/lib/src/queue.dart
+++ b/packages/player/lib/src/queue.dart
@@ -41,7 +41,7 @@ class Queue {
   Media? _current;
 
   set setIndex(int index) {
-    if (storage.isNotEmpty && index >= 0 && index < storage.length) {
+    if (storage.isNotEmpty && index >= 0 && index < storage.length - 1) {
       _index = index;
       _current = storage[index].item;
     }
@@ -106,8 +106,11 @@ class Queue {
     setIndex = 0;
   }
 
-  replaceCurrent(Media media) =>
+  void replaceCurrent(Media media) {
+    if (index > -1 && index <= (storage.length - 1) && storage.isNotEmpty) {
       storage[index] = storage[index].copyWith(item: media);
+    }
+  }
 
   add(Media media) async {
     int pos = _nextPosition();

--- a/packages/player/lib/src/queue.dart
+++ b/packages/player/lib/src/queue.dart
@@ -107,7 +107,7 @@ class Queue {
   }
 
   void replaceCurrent(Media media) {
-    if (index > -1 && index <= (storage.length - 1) && storage.isNotEmpty) {
+    if (storage.isNotEmpty && index > -1 && index <= (storage.length - 1)) {
       storage[index] = storage[index].copyWith(item: media);
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the media queue handling to prevent out-of-bounds errors when setting the current index or replacing the current media item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->