### PR TITLE
only notify if is playing

### DIFF
--- a/packages/player/android/src/main/kotlin/br/com/suamusica/player/MediaService.kt
+++ b/packages/player/android/src/main/kotlin/br/com/suamusica/player/MediaService.kt
@@ -686,7 +686,9 @@ class MediaService : androidx.media.MediaBrowserServiceCompat() {
         }
 
         override fun run() {
-            notifyPositionChange()
+            if(previousState == PlaybackStateCompat.STATE_PLAYING) {
+                notifyPositionChange()
+            }
 
             if (!shutdownRequest.get()) {
                 handler.postDelayed(this, 800 /* ms */)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback progress tracking to update only when audio is actively playing, preventing unnecessary updates in other states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->